### PR TITLE
Dont delete last compiled assembly

### DIFF
--- a/Source/MBansheeEditor/Script/ScriptCompiler.cs
+++ b/Source/MBansheeEditor/Script/ScriptCompiler.cs
@@ -174,9 +174,6 @@ namespace BansheeEditor
             for (int i = 0; i < files.Length; i++)
                 argumentsBuilder.Append(" \"" + files[i] + "\"");
 
-            if (File.Exists(outputFile))
-                File.Delete(outputFile);
-
             string outputDir = Path.GetDirectoryName(outputFile);
             if (!Directory.Exists(outputDir))
                 Directory.CreateDirectory(outputDir);


### PR DESCRIPTION
Since generated assembly was deleted each time before compiling, it would prevent user from editing existing attached script components due to the missing assembly if there's any error in compilation. 

One possible solution is displaying nagging overly stating "There was compile error in your scripts, please fix it...", but meanwhile still let user editing the scene if they choose to.