### PR TITLE
Linux & OS X fixes

### DIFF
--- a/Source/BansheeCore/Include/BsCollider.h
+++ b/Source/BansheeCore/Include/BsCollider.h
@@ -2,6 +2,8 @@
 //**************** Copyright (c) 2016 Marko Pintera (marko.pintera@gmail.com). All rights reserved. **********************//
 #pragma once
 
+#include <cfloat>
+
 #include "BsCorePrerequisites.h"
 #include "BsPhysicsCommon.h"
 #include "BsVector3.h"

--- a/Source/BansheeCore/Include/BsGpuProgram.h
+++ b/Source/BansheeCore/Include/BsGpuProgram.h
@@ -232,3 +232,18 @@ namespace BansheeEngine
 
 	/** @} */
 }
+
+namespace std
+{
+/** Hash value generator for GpuProgramProfile. */
+template<>
+struct hash<BansheeEngine::GpuProgramProfile>
+{
+	size_t operator()(const BansheeEngine::GpuProgramProfile& profile) const
+	{
+		size_t hash = 0;
+		BansheeEngine::hash_combine(hash, (int)profile);
+		return hash;
+	}
+};
+}

--- a/Source/BansheeCore/Include/BsJoint.h
+++ b/Source/BansheeCore/Include/BsJoint.h
@@ -2,6 +2,8 @@
 //**************** Copyright (c) 2016 Marko Pintera (marko.pintera@gmail.com). All rights reserved. **********************//
 #pragma once
 
+#include <cfloat>
+
 #include "BsCorePrerequisites.h"
 #include "BsPhysicsCommon.h"
 #include "BsFJoint.h"

--- a/Source/BansheeGLRenderAPI/Include/BsGLPrerequisites.h
+++ b/Source/BansheeGLRenderAPI/Include/BsGLPrerequisites.h
@@ -24,7 +24,7 @@
 #   include <GL/glew.h>
 #   include <GL/glu.h>
 #   define GL_GLEXT_PROTOTYPES
-#elif BS_PLATFORM == BS_PLATFORM_APPLE
+#elif BS_PLATFORM == BS_PLATFORM_OSX
 #   include <GL/glew.h>
 #   include <OpenGL/glu.h>
 #endif

--- a/Source/BansheeOISInput/Source/BsInputHandlerOIS.cpp
+++ b/Source/BansheeOISInput/Source/BsInputHandlerOIS.cpp
@@ -73,7 +73,7 @@ namespace BansheeEngine
 		pl.insert(std::make_pair(std::string("w32_mouse"), std::string("DISCL_NONEXCLUSIVE")));
 		pl.insert(std::make_pair(std::string("w32_keyboard"), std::string("DISCL_FOREGROUND")));
 		pl.insert(std::make_pair(std::string("w32_keyboard"), std::string("DISCL_NONEXCLUSIVE")));
-#elif defined BS_PLATFORM == BS_PLATFORM_LINUX || BS_PLATFORM == BS_PLATFORM_APPLE
+#elif defined BS_PLATFORM == BS_PLATFORM_LINUX || BS_PLATFORM == BS_PLATFORM_OSX
 		pl.insert(std::make_pair(std::string("x11_mouse_grab"), std::string("false")));
 		pl.insert(std::make_pair(std::string("x11_mouse_hide"), std::string("false")));
 		pl.insert(std::make_pair(std::string("x11_keyboard_grab"), std::string("false")));

--- a/Source/BansheeUtility/Include/BsAny.h
+++ b/Source/BansheeUtility/Include/BsAny.h
@@ -52,7 +52,7 @@ namespace BansheeEngine
 			:mData(bs_new<Data<ValueType>>(value))
 		{ }
 
-		Any(nullptr_t)
+		Any(std::nullptr_t)
 			:mData(nullptr)
 		{ }
 

--- a/Source/BansheeUtility/Include/BsDynLib.h
+++ b/Source/BansheeUtility/Include/BsDynLib.h
@@ -27,7 +27,7 @@ namespace BansheeEngine
 #    define DYNLIB_GETSYM( a, b ) dlsym( a, b )
 #    define DYNLIB_UNLOAD( a ) dlclose( a )
 
-#elif BS_PLATFORM == BS_PLATFORM_APPLE
+#elif BS_PLATFORM == BS_PLATFORM_OSX
 #    define DYNLIB_HANDLE void*
 #    define DYNLIB_LOAD( a ) mac_loadDylib( a )
 #    define DYNLIB_GETSYM( a, b ) dlsym( a, b )

--- a/Source/BansheeUtility/Include/BsDynLib.h
+++ b/Source/BansheeUtility/Include/BsDynLib.h
@@ -21,15 +21,9 @@ namespace BansheeEngine
 #    define DYNLIB_GETSYM( a, b ) GetProcAddress( a, b )
 #    define DYNLIB_UNLOAD( a ) !FreeLibrary( a )
 
-#elif BS_PLATFORM == BS_PLATFORM_LINUX
+#elif BS_PLATFORM == BS_PLATFORM_LINUX || BS_PLATFORM == BS_PLATFORM_OSX
 #    define DYNLIB_HANDLE void*
 #    define DYNLIB_LOAD( a ) dlopen( a, RTLD_LAZY | RTLD_GLOBAL)
-#    define DYNLIB_GETSYM( a, b ) dlsym( a, b )
-#    define DYNLIB_UNLOAD( a ) dlclose( a )
-
-#elif BS_PLATFORM == BS_PLATFORM_OSX
-#    define DYNLIB_HANDLE void*
-#    define DYNLIB_LOAD( a ) mac_loadDylib( a )
 #    define DYNLIB_GETSYM( a, b ) dlsym( a, b )
 #    define DYNLIB_UNLOAD( a ) dlclose( a )
 

--- a/Source/BansheeUtility/Include/BsMemoryAllocator.h
+++ b/Source/BansheeUtility/Include/BsMemoryAllocator.h
@@ -1,11 +1,12 @@
 //********************************** Banshee Engine (www.banshee3d.com) **************************************************//
 //**************** Copyright (c) 2016 Marko Pintera (marko.pintera@gmail.com). All rights reserved. **********************//
 #pragma once
-
 #undef min
 #undef max
 
 #include <atomic>
+#include <limits>
+#include <new>                  /* For 'placement new' */
 #include <utility>
 
 #if BS_PLATFORM == BS_PLATFORM_LINUX
@@ -377,16 +378,24 @@ namespace BansheeEngine
 	 *  @{
 	 */
 
-    /** Allocator for the standard library that internally uses Banshee memory allocator. */
-    template <class T, class Alloc = GenAlloc>
+	/** Allocator for the standard library that internally uses Banshee memory allocator. */
+	template <class T, class Alloc = GenAlloc>
 	class StdAlloc 
 	{
 	public:
 		typedef T value_type;
+		typedef T* pointer;
+		typedef const T* const_pointer;
+		typedef T& reference;
+		typedef const T& const_reference;
+		typedef std::size_t size_type;
+		typedef std::ptrdiff_t difference_type;
+
 		StdAlloc() noexcept {}
-		template<class T, class Alloc> StdAlloc(const StdAlloc<T, Alloc>&) noexcept {}
-		template<class T, class Alloc> bool operator==(const StdAlloc<T, Alloc>&) const noexcept { return true; }
-		template<class T, class Alloc> bool operator!=(const StdAlloc<T, Alloc>&) const noexcept { return false; }
+		template<class U, class Alloc2> StdAlloc(const StdAlloc<U, Alloc2>&) noexcept {}
+		template<class U, class Alloc2> bool operator==(const StdAlloc<U, Alloc2>&) const noexcept { return true; }
+		template<class U, class Alloc2> bool operator!=(const StdAlloc<U, Alloc2>&) const noexcept { return false; }
+		template<class U> class rebind { public: typedef StdAlloc<U, Alloc> other; };
 
 		/** Allocate but don't initialize number elements of type T. */
 		T* allocate(const size_t num) const
@@ -409,6 +418,12 @@ namespace BansheeEngine
 		{
 			bs_free<Alloc>((void*)p);
 		}
+
+		size_t max_size() const { return std::numeric_limits<size_type>::max() / sizeof(T); }
+		void construct(pointer p, const_reference t) { new (p) T(t); }
+		void destroy(pointer p) { p->~T(); }
+		template<class U, class... Args>
+		void construct(U* p, Args&&... args) { new(p) U(std::forward<Args>(args)...); }
 	};
 
 	/** @} */

--- a/Source/BansheeUtility/Include/BsPlatformDefines.h
+++ b/Source/BansheeUtility/Include/BsPlatformDefines.h
@@ -51,7 +51,7 @@
 #if defined( __WIN32__ ) || defined( _WIN32 )
 #   define BS_PLATFORM BS_PLATFORM_WIN32
 #elif defined( __APPLE_CC__)
-#   define BS_PLATFORM BS_PLATFORM_APPLE
+#   define BS_PLATFORM BS_PLATFORM_OSX
 #else
 #   define BS_PLATFORM BS_PLATFORM_LINUX
 #endif

--- a/Source/BansheeUtility/Include/BsRTTIType.h
+++ b/Source/BansheeUtility/Include/BsRTTIType.h
@@ -546,7 +546,7 @@ namespace BansheeEngine
 
 			UINT32 typeSize = 0;
 			if(field->hasDynamicSize())
-				typeSize = field->getArrayElemDynamicSize(object, arrIdx);
+				typeSize = field->getArrayElemDynamicSize(object, index);
 			else
 				typeSize = field->getTypeSize();
 

--- a/Source/BansheeUtility/Include/BsVectorNI.h
+++ b/Source/BansheeUtility/Include/BsVectorNI.h
@@ -52,7 +52,7 @@ namespace BansheeEngine
 		{
 			for (UINT32 i = 0; i < N; i++)
 			{
-				if (v[i] != rhs.v[i])
+				if (v[i] != rhs[i])
 					return false;
 			}
 

--- a/Source/BansheeUtility/Source/BsDynLib.cpp
+++ b/Source/BansheeUtility/Source/BsDynLib.cpp
@@ -96,7 +96,7 @@ namespace BansheeEngine
         // Free the buffer.
         LocalFree(lpMsgBuf);
         return ret;
-#elif BS_PLATFORM == BS_PLATFORM_LINUX || BS_PLATFORM == BS_PLATFORM_APPLE
+#elif BS_PLATFORM == BS_PLATFORM_LINUX || BS_PLATFORM == BS_PLATFORM_OSX
         return String(dlerror());
 #else
         return String("");

--- a/Source/BansheeUtility/Source/BsDynLib.cpp
+++ b/Source/BansheeUtility/Source/BsDynLib.cpp
@@ -12,7 +12,6 @@
 #endif
 
 #if BS_PLATFORM == BS_PLATFORM_OSX
-#   include "macUtils.h"
 #   include <dlfcn.h>
 #endif
 

--- a/Source/BansheeUtility/Source/BsPath.cpp
+++ b/Source/BansheeUtility/Source/BsPath.cpp
@@ -117,7 +117,7 @@ namespace BansheeEngine
 		default:
 #if BS_PLATFORM == BS_PLATFORM_WIN32
 			parseWindows(pathStr, numChars);
-#elif BS_PLATFORM == BS_PLATFORM_APPLE || BS_PLATFORM == BS_PLATFORM_LINUX
+#elif BS_PLATFORM == BS_PLATFORM_OSX || BS_PLATFORM == BS_PLATFORM_LINUX
 			parseUnix(pathStr, numChars);
 #else
 			static_assert(false, "Unsupported platform for path.");
@@ -139,7 +139,7 @@ namespace BansheeEngine
 		default:
 #if BS_PLATFORM == BS_PLATFORM_WIN32
 			parseWindows(pathStr, numChars);
-#elif BS_PLATFORM == BS_PLATFORM_APPLE || BS_PLATFORM == BS_PLATFORM_LINUX
+#elif BS_PLATFORM == BS_PLATFORM_OSX || BS_PLATFORM == BS_PLATFORM_LINUX
 			parseUnix(pathStr, numChars);
 #else
 			static_assert(false, "Unsupported platform for path.");
@@ -159,7 +159,7 @@ namespace BansheeEngine
 		default:
 #if BS_PLATFORM == BS_PLATFORM_WIN32
 			return buildWindows();
-#elif BS_PLATFORM == BS_PLATFORM_APPLE || BS_PLATFORM == BS_PLATFORM_LINUX
+#elif BS_PLATFORM == BS_PLATFORM_OSX || BS_PLATFORM == BS_PLATFORM_LINUX
 			return buildUnix();
 #else
 			static_assert(false, "Unsupported platform for path.");
@@ -179,7 +179,7 @@ namespace BansheeEngine
 		default:
 #if BS_PLATFORM == BS_PLATFORM_WIN32
 			return BansheeEngine::toString(buildWindows());
-#elif BS_PLATFORM == BS_PLATFORM_APPLE || BS_PLATFORM == BS_PLATFORM_LINUX
+#elif BS_PLATFORM == BS_PLATFORM_OSX || BS_PLATFORM == BS_PLATFORM_LINUX
 			return BansheeEngine::toString(buildUnix());
 #else
 			static_assert(false, "Unsupported platform for path.");

--- a/Source/BansheeUtility/Source/BsThreadPool.cpp
+++ b/Source/BansheeUtility/Source/BsThreadPool.cpp
@@ -1,6 +1,7 @@
 //********************************** Banshee Engine (www.banshee3d.com) **************************************************//
 //**************** Copyright (c) 2016 Marko Pintera (marko.pintera@gmail.com). All rights reserved. **********************//
 #include "BsThreadPool.h"
+#include "BsDebug.h"
 
 #if BS_PLATFORM == BS_PLATFORM_WIN32
 #include "windows.h"


### PR DESCRIPTION
Hi! I'm back.

Here are yet another bunch of fixes on Linux (and OS X!), mostly minor things, I think, except maybe a few methods in allocators.

I'm curious to know if it builds on Windows. (On OS X, StdAlloc::construct(U* p, Args&&... args) yields a build error.)

Best,
Marc