### PR TITLE
fix Clang build

### DIFF
--- a/Source/BansheeUtility/Include/BsTimer.h
+++ b/Source/BansheeUtility/Include/BsTimer.h
@@ -39,7 +39,7 @@ namespace BansheeEngine
 
 	private:
 		std::chrono::high_resolution_clock mHRClock;
-		std::chrono::steady_clock::time_point mStartTime;
+		std::chrono::time_point<std::chrono::high_resolution_clock> mStartTime;
     };
 
 	/** @} */

--- a/Source/BansheeUtility/Source/BsTimer.cpp
+++ b/Source/BansheeUtility/Source/BsTimer.cpp
@@ -21,7 +21,7 @@ namespace BansheeEngine
 
 	UINT64 Timer::getMilliseconds() const
 	{
-		steady_clock::time_point newTime = mHRClock.now();
+		auto newTime = mHRClock.now();
 		nanoseconds newTimeNs = newTime.time_since_epoch();
 
 		return duration_cast<milliseconds>(newTimeNs).count();
@@ -29,7 +29,7 @@ namespace BansheeEngine
 
 	UINT64 Timer::getMicroseconds() const
 	{
-		steady_clock::time_point newTime = mHRClock.now();
+		auto newTime = mHRClock.now();
 		nanoseconds newTimeNs = newTime.time_since_epoch();
 
 		return duration_cast<microseconds>(newTimeNs).count();


### PR DESCRIPTION
According to C++ std std::chrono::high_resolution_clock is alias,
and in VS it's alias for steady_clock,
and in Clang it's alias for system_clock.

So to avoid problems I've changed BsTimer code to use
`std::chrono::high_resolution_clock` instead of
specialized variable type.