### PR TITLE
Fix editor crash on creating GUI Widget component

### DIFF
--- a/Source/SBansheeEngine/Source/BsScriptGUIWidget.cpp
+++ b/Source/SBansheeEngine/Source/BsScriptGUIWidget.cpp
@@ -25,7 +25,7 @@ namespace BansheeEngine
 		MonoObject* guiPanel = ScriptGUIPanel::createFromExisting(mGUIWidget->getPanel());
 		mPanel = ScriptGUILayout::toNative(guiPanel);
 
-		sGUIPanelField->setValue(nullptr, guiPanel);
+		sGUIPanelField->setValue(managedInstance, guiPanel);
 	}
 
 	ScriptGUIWidget::~ScriptGUIWidget()


### PR DESCRIPTION
Fixes crash on editor which occurs on creating a GUI widget component (Components > GUI widget)