### PR TITLE
Solved C3861 __cpuid&__rdtsc identifier not found

### DIFF
--- a/Source/BansheeCore/Source/BsProfilerCPU.cpp
+++ b/Source/BansheeCore/Source/BsProfilerCPU.cpp
@@ -5,6 +5,10 @@
 #include "BsPlatform.h"
 #include <chrono>
 
+#if BS_COMPILER == BS_COMPILER_MSVC
+	#include <intrin.h>
+#endif
+
 #if BS_COMPILER == BS_COMPILER_GNUC || BS_COMPILER == BS_COMPILER_CLANG
 	#include "cpuid.h"
 #endif


### PR DESCRIPTION
error C3861: '__cpuid ': identifier not found
error C3861: '__rdtsc ': identifier not found