### PR TITLE
Fixed several memory leaks and bugfixes

### DIFF
--- a/Source/BansheeCore/Include/BsCommonTypes.h
+++ b/Source/BansheeCore/Include/BsCommonTypes.h
@@ -166,7 +166,7 @@ namespace bs
 		 * However it is hard to guarantee when GPU has finished using a buffer.
 		 */
 		GBL_WRITE_ONLY_NO_OVERWRITE,
-		/** Allows you to both read and write to a buffer. */
+		/** Allows you to write to a buffer. */
 		GBL_WRITE_ONLY	
 	};
 

--- a/Source/BansheeCore/Include/BsProfilerGPU.h
+++ b/Source/BansheeCore/Include/BsProfilerGPU.h
@@ -9,8 +9,8 @@
 namespace bs
 {
 	/** @addtogroup Profiling
-	 *  @{
-	 */
+	*  @{
+	*/
 
 	/** Contains various profiler statistics about a single GPU profiling sample. */
 	struct GPUProfileSample
@@ -48,10 +48,10 @@ namespace bs
 	};
 
 	/**
-	 * Profiler that measures time and amount of various GPU operations.
-	 *
-	 * @note	Core thread only except where noted otherwise.
-	 */
+	* Profiler that measures time and amount of various GPU operations.
+	*
+	* @note	Core thread only except where noted otherwise.
+	*/
 	class BS_CORE_EXPORT ProfilerGPU : public Module<ProfilerGPU>
 	{
 	private:
@@ -72,67 +72,68 @@ namespace bs
 
 	public:
 		ProfilerGPU();
+		~ProfilerGPU();
 
 		/**
-		 * Signals a start of a new frame. Every frame will generate a separate profiling report. This call must be followed
-		 * by endFrame(), and any sampling operations must happen between beginFrame() and endFrame().
-		 */
+		* Signals a start of a new frame. Every frame will generate a separate profiling report. This call must be followed
+		* by endFrame(), and any sampling operations must happen between beginFrame() and endFrame().
+		*/
 		void beginFrame();
 
 		/**
-		 * Signals an end of the currently sampled frame. Results of the sampling will be available once 
-		 * getNumAvailableReports increments. This may take a while as the sampling is scheduled on the core thread and 
-		 * on the GPU.
-		 */
+		* Signals an end of the currently sampled frame. Results of the sampling will be available once
+		* getNumAvailableReports increments. This may take a while as the sampling is scheduled on the core thread and
+		* on the GPU.
+		*/
 		void endFrame();
 
 		/**
-		 * Begins sample measurement. Must be followed by endSample().
-		 *
-		 * @param[in]	name	Unique name for the sample you can later use to find the sampling data.
-		 *
-		 * @note	Must be called between beginFrame()/endFrame() calls.
-		 */
+		* Begins sample measurement. Must be followed by endSample().
+		*
+		* @param[in]	name	Unique name for the sample you can later use to find the sampling data.
+		*
+		* @note	Must be called between beginFrame()/endFrame() calls.
+		*/
 		void beginSample(const ProfilerString& name);
 
 		/**
-		 * Ends sample measurement.
-		 *
-		 * @param[in]	name	Unique name for the sample.
-		 *
-		 * @note	
-		 * Unique name is primarily needed to more easily identify mismatched begin/end sample pairs. Otherwise the name in 
-		 * beginSample() would be enough. Must be called between beginFrame()/endFrame() calls.
-		 */
+		* Ends sample measurement.
+		*
+		* @param[in]	name	Unique name for the sample.
+		*
+		* @note
+		* Unique name is primarily needed to more easily identify mismatched begin/end sample pairs. Otherwise the name in
+		* beginSample() would be enough. Must be called between beginFrame()/endFrame() calls.
+		*/
 		void endSample(const ProfilerString& name);
 
 		/**
-		 * Returns number of profiling reports that are ready but haven't been retrieved yet. 
-		 *
-		 * @note	
-		 * There is an internal limit of maximum number of available reports, where oldest ones will get deleted so make 
-		 * sure to call this often if you don't want to miss some.
-		 * @note
-		 * Thread safe.
-		 */
+		* Returns number of profiling reports that are ready but haven't been retrieved yet.
+		*
+		* @note
+		* There is an internal limit of maximum number of available reports, where oldest ones will get deleted so make
+		* sure to call this often if you don't want to miss some.
+		* @note
+		* Thread safe.
+		*/
 		UINT32 getNumAvailableReports();
 
 		/**
-		 * Gets the oldest report available and removes it from the internal list. Throws an exception if no reports are 
-		 * available.
-		 *
-		 * @note	Thread safe.
-		 */
+		* Gets the oldest report available and removes it from the internal list. Throws an exception if no reports are
+		* available.
+		*
+		* @note	Thread safe.
+		*/
 		GPUProfilerReport getNextReport();
 
 	public: // ***** INTERNAL ******
-		/** @name Internal
-		 *  @{
-		 */
+			/** @name Internal
+			*  @{
+			*/
 
-		/**
-		 * To be called once per frame from the Core thread.
-		 */
+			/**
+			* To be called once per frame from the Core thread.
+			*/
 		void _update();
 
 		/** @} */
@@ -151,9 +152,9 @@ namespace bs
 		SPtr<ct::OcclusionQuery> getOcclusionQuery() const;
 
 		/**
-		 * Interprets the active frame results and generates a profiler report for the frame. Provided frame queries must 
-		 * have finished before calling this.
-		 */
+		* Interprets the active frame results and generates a profiler report for the frame. Provided frame queries must
+		* have finished before calling this.
+		*/
 		GPUProfilerReport resolveFrame(ActiveFrame& frame);
 
 		/** Resolves an active sample and converts it to report sample. */
@@ -165,7 +166,11 @@ namespace bs
 		Stack<UINT32> mActiveSampleIndexes;
 
 		Queue<ActiveFrame> mUnresolvedFrames;
-		Queue<GPUProfilerReport> mReadyReports;
+		GPUProfilerReport* mReadyReports;
+
+		static const UINT32 MAX_QUEUE_ELEMENTS;
+		UINT32 mReportHeadPos;
+		UINT32 mReportCount;
 
 		mutable Stack<SPtr<ct::TimerQuery>> mFreeTimerQueries;
 		mutable Stack<SPtr<ct::OcclusionQuery>> mFreeOcclusionQueries;

--- a/Source/BansheeCore/Include/BsProfilerGPU.h
+++ b/Source/BansheeCore/Include/BsProfilerGPU.h
@@ -48,10 +48,10 @@ namespace bs
 	};
 
 	/**
-	* Profiler that measures time and amount of various GPU operations.
-	*
-	* @note	Core thread only except where noted otherwise.
-	*/
+	 * Profiler that measures time and amount of various GPU operations.
+	 *
+	 * @note	Core thread only except where noted otherwise.
+	 */
 	class BS_CORE_EXPORT ProfilerGPU : public Module<ProfilerGPU>
 	{
 	private:
@@ -75,65 +75,66 @@ namespace bs
 		~ProfilerGPU();
 
 		/**
-		* Signals a start of a new frame. Every frame will generate a separate profiling report. This call must be followed
-		* by endFrame(), and any sampling operations must happen between beginFrame() and endFrame().
-		*/
+		 * Signals a start of a new frame. Every frame will generate a separate profiling report. This call must be followed
+		 * by endFrame(), and any sampling operations must happen between beginFrame() and endFrame().
+		 */
 		void beginFrame();
 
 		/**
-		* Signals an end of the currently sampled frame. Results of the sampling will be available once
-		* getNumAvailableReports increments. This may take a while as the sampling is scheduled on the core thread and
-		* on the GPU.
-		*/
+		 * Signals an end of the currently sampled frame. Results of the sampling will be available once
+		 * getNumAvailableReports increments. This may take a while as the sampling is scheduled on the core thread and
+		 * on the GPU.
+		 */
 		void endFrame();
 
 		/**
-		* Begins sample measurement. Must be followed by endSample().
-		*
-		* @param[in]	name	Unique name for the sample you can later use to find the sampling data.
-		*
-		* @note	Must be called between beginFrame()/endFrame() calls.
-		*/
+		 * Begins sample measurement. Must be followed by endSample().
+		 *
+		 * @param[in]	name	Unique name for the sample you can later use to find the sampling data.
+		 *
+		 * @note	Must be called between beginFrame()/endFrame() calls.
+		 */
 		void beginSample(const ProfilerString& name);
 
 		/**
-		* Ends sample measurement.
-		*
-		* @param[in]	name	Unique name for the sample.
-		*
-		* @note
-		* Unique name is primarily needed to more easily identify mismatched begin/end sample pairs. Otherwise the name in
-		* beginSample() would be enough. Must be called between beginFrame()/endFrame() calls.
-		*/
+		 * Ends sample measurement.
+		 *
+		 * @param[in]	name	Unique name for the sample.
+		 *
+		 * @note
+		 * Unique name is primarily needed to more easily identify mismatched begin/end sample pairs. Otherwise the name in
+		 * beginSample() would be enough. Must be called between beginFrame()/endFrame() calls.
+		 */
 		void endSample(const ProfilerString& name);
 
 		/**
-		* Returns number of profiling reports that are ready but haven't been retrieved yet.
-		*
-		* @note
-		* There is an internal limit of maximum number of available reports, where oldest ones will get deleted so make
-		* sure to call this often if you don't want to miss some.
-		* @note
-		* Thread safe.
-		*/
+		 * Returns number of profiling reports that are ready but haven't been retrieved yet.
+		 *
+		 * @note
+		 * There is an internal limit of maximum number of available reports, where oldest ones will get deleted so make
+		 * sure to call this often if you don't want to miss some.
+		 * @note
+		 * Thread safe.
+		 */
 		UINT32 getNumAvailableReports();
 
 		/**
-		* Gets the oldest report available and removes it from the internal list. Throws an exception if no reports are
-		* available.
-		*
-		* @note	Thread safe.
-		*/
+		 * Gets the oldest report available and removes it from the internal list. Throws an exception if no reports are
+		 * available.
+		 *
+		 * @note	Thread safe.
+		 */
 		GPUProfilerReport getNextReport();
 
-	public: // ***** INTERNAL ******
-			/** @name Internal
-			*  @{
-			*/
+	public: 
+		// ***** INTERNAL ******
+		/** @name Internal
+		 *  @{
+		 */
 
-			/**
-			* To be called once per frame from the Core thread.
-			*/
+		/**
+		 * To be called once per frame from the Core thread.
+		 */
 		void _update();
 
 		/** @} */
@@ -152,9 +153,9 @@ namespace bs
 		SPtr<ct::OcclusionQuery> getOcclusionQuery() const;
 
 		/**
-		* Interprets the active frame results and generates a profiler report for the frame. Provided frame queries must
-		* have finished before calling this.
-		*/
+		 * Interprets the active frame results and generates a profiler report for the frame. Provided frame queries must
+		 * have finished before calling this.
+		 */
 		GPUProfilerReport resolveFrame(ActiveFrame& frame);
 
 		/** Resolves an active sample and converts it to report sample. */

--- a/Source/BansheeCore/Source/BsHString.cpp
+++ b/Source/BansheeCore/Source/BsHString.cpp
@@ -11,7 +11,7 @@ namespace bs
 	{
 		mStringData = StringTableManager::instance().getTable(stringTableId)->getStringData(L"");
 
-		if(mStringData->numParameters > 0)
+		if (mStringData->numParameters > 0)
 			mParameters = bs_newN<WString>(mStringData->numParameters);
 	}
 
@@ -20,7 +20,7 @@ namespace bs
 	{
 		mStringData = StringTableManager::instance().getTable(stringTableId)->getStringData(identifierString);
 
-		if(mStringData->numParameters > 0)
+		if (mStringData->numParameters > 0)
 			mParameters = bs_newN<WString>(mStringData->numParameters);
 	}
 
@@ -38,7 +38,26 @@ namespace bs
 
 	HString::HString(const HString& copy)
 	{
-		*this = copy;
+		mStringData = copy.mStringData;
+		mIsDirty = copy.mIsDirty;
+		mCachedString = copy.mCachedString;
+
+		if (copy.mStringData->numParameters > 0)
+		{
+			mParameters = bs_newN<WString>(mStringData->numParameters);
+			if (copy.mParameters != nullptr)
+			{
+				for (UINT32 i = 0; i < mStringData->numParameters; i++)
+					mParameters[i] = copy.mParameters[i];
+			}
+
+			mStringPtr = &mCachedString;
+		}
+		else
+		{
+			mParameters = nullptr;
+			mStringPtr = &mStringData->string;
+		}
 	}
 
 	HString::~HString()
@@ -47,13 +66,19 @@ namespace bs
 			bs_deleteN(mParameters, mStringData->numParameters);
 	}
 
-	HString::operator const WString& () const 
-	{ 
-		return getValue(); 
+	HString::operator const WString& () const
+	{
+		return getValue();
 	}
 
 	HString& HString::operator=(const HString& rhs)
 	{
+		if (mParameters != nullptr)
+		{
+			bs_deleteN(mParameters, mStringData->numParameters);
+			mParameters = nullptr;
+		}
+
 		mStringData = rhs.mStringData;
 		mIsDirty = rhs.mIsDirty;
 		mCachedString = rhs.mCachedString;
@@ -80,9 +105,9 @@ namespace bs
 
 	const WString& HString::getValue() const
 	{
-		if(mIsDirty)
+		if (mIsDirty)
 		{
-			if(mParameters != nullptr)
+			if (mParameters != nullptr)
 			{
 				mStringData->concatenateString(mCachedString, mParameters, mStringData->numParameters);
 				mStringPtr = &mCachedString;
@@ -95,7 +120,7 @@ namespace bs
 			mIsDirty = false;
 		}
 
-		return *mStringPtr; 
+		return *mStringPtr;
 	}
 
 	void HString::setParameter(UINT32 idx, const WString& value)

--- a/Source/BansheeUtility/Source/BsFrameAlloc.cpp
+++ b/Source/BansheeUtility/Source/BsFrameAlloc.cpp
@@ -235,6 +235,8 @@ namespace bs
 
 				allocBlock(totalBytes);
 			}
+			else
+				mBlocks[0]->mFreePtr = 0;
 		}
 	}
 

--- a/Source/BansheeUtility/Source/BsThreadPool.cpp
+++ b/Source/BansheeUtility/Source/BsThreadPool.cpp
@@ -261,8 +261,11 @@ namespace bs
 
 		for(auto& thread : idleThreads)
 		{
-			if(i < limit)
+			if (i < limit)
+			{
 				mThreads.push_back(thread);
+				i++;
+			}
 			else
 				destroyThread(thread);
 		}


### PR DESCRIPTION
Memory leaks fixes:

- Replaced the existing queue with a circular buffer in ProfilerGPU to store the reports to avoid size increasing indefinitely.

- Changed HString copy constructor and assignment operators to avoid orphaned memory

- Fixed ThreadPool not deleting some idle threads

- In FrameAlloc reset mFreePtr of the current block when clear is called, avoiding memory leak

Other fixes:

- ThreadPool not deleting some idle threads

- Typo in comments
