### PR TITLE
Linux x11 input

### DIFF
--- a/Source/BansheeCore/Linux/BsLinuxInput.cpp
+++ b/Source/BansheeCore/Linux/BsLinuxInput.cpp
@@ -238,40 +238,6 @@ namespace bs
 		return isGamepad;
 	}
 
-	/** Checks is the event handler at the specified input file handle is a mouse. */
-	bool isMouse(int fileHandle)
-	{
-		EventInfo eventInfo;
-		if(!getEventInfo(fileHandle, eventInfo))
-			return false;
-
-		// Check for mouse buttons
-		for(auto& entry : eventInfo.buttons)
-		{
-			if((entry >= BTN_MOUSE && entry < BTN_JOYSTICK))
-				return true;
-		}
-
-		return false;
-	}
-
-	/** Checks is the event handler at the specified input file handle is a keyboard. */
-	bool isKeyboard(int fileHandle)
-	{
-		EventInfo eventInfo;
-		if(!getEventInfo(fileHandle, eventInfo))
-			return false;
-
-		// Check for keyboard keys
-		for(auto& entry : eventInfo.buttons)
-		{
-			if(entry >= KEY_ESC && entry < KEY_KPDOT)
-				return true;
-		}
-
-		return false;
-	}
-
 	void Input::initRawInput()
 	{
 		mPlatformData = bs_new<InputPrivateData>();
@@ -295,19 +261,12 @@ namespace bs
 				info.id = (UINT32)mPlatformData->gamepadInfos.size();
 				mPlatformData->gamepadInfos.push_back(info);
 			}
-			else if(isKeyboard(file))
-				mPlatformData->keyboards.push_back(i);
-			else if(isMouse(file))
-				mPlatformData->mice.push_back(i);
 
 			close(file);
 		}
 
-		if (getDeviceCount(InputDevice::Keyboard) > 0)
-			mKeyboard = bs_new<Keyboard>("Keyboard", this);
-
-		if (getDeviceCount(InputDevice::Mouse) > 0)
-			mMouse = bs_new<Mouse>("Mouse", this);
+		mKeyboard = bs_new<Keyboard>("Keyboard", this);
+		mMouse = bs_new<Mouse>("Mouse", this);
 
 		UINT32 numGamepads = getDeviceCount(InputDevice::Gamepad);
 		for (UINT32 i = 0; i < numGamepads; i++)

--- a/Source/BansheeCore/Linux/BsLinuxInput.h
+++ b/Source/BansheeCore/Linux/BsLinuxInput.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "BsCorePrerequisites.h"
+#include "Input/BsInputFwd.h"
 
 namespace bs
 {
@@ -34,6 +35,30 @@ namespace bs
 		Vector<GamepadInfo> gamepadInfos;
 		Vector<INT32> mice;
 		Vector<INT32> keyboards;
+	};
+
+	/**
+	 * Data about relative pointer / scroll wheel movement.
+	 */
+	struct LinuxMouseMotionEvent
+	{
+		double deltaX;
+		double deltaY;
+
+		/**
+		 * Relative vertical scroll amount.
+		 */
+		double deltaZ;
+	};
+
+	/**
+	 * Data about a single button press or release.
+	 */
+	struct LinuxButtonEvent
+	{
+		UINT64 timestamp;
+		ButtonCode button;
+		bool pressed;
 	};
 
 #define BUFFER_SIZE_GAMEPAD 64

--- a/Source/BansheeCore/Linux/BsLinuxInput.h
+++ b/Source/BansheeCore/Linux/BsLinuxInput.h
@@ -33,8 +33,6 @@ namespace bs
 	struct InputPrivateData
 	{
 		Vector<GamepadInfo> gamepadInfos;
-		Vector<INT32> mice;
-		Vector<INT32> keyboards;
 	};
 
 	/**

--- a/Source/BansheeCore/Linux/BsLinuxInput.h
+++ b/Source/BansheeCore/Linux/BsLinuxInput.h
@@ -35,23 +35,15 @@ namespace bs
 		Vector<GamepadInfo> gamepadInfos;
 	};
 
-	/**
-	 * Data about relative pointer / scroll wheel movement.
-	 */
+	/** Data about relative pointer / scroll wheel movement. */
 	struct LinuxMouseMotionEvent
 	{
-		double deltaX;
-		double deltaY;
-
-		/**
-		 * Relative vertical scroll amount.
-		 */
-		double deltaZ;
+		double deltaX; /**< Relative pointer movement in X direction. */
+		double deltaY; /**< Relative pointer movement in Y direction. */
+		double deltaZ; /**< Relative vertical scroll amount. */
 	};
 
-	/**
-	 * Data about a single button press or release.
-	 */
+	/** Data about a single button press or release. */
 	struct LinuxButtonEvent
 	{
 		UINT64 timestamp;
@@ -60,7 +52,5 @@ namespace bs
 	};
 
 #define BUFFER_SIZE_GAMEPAD 64
-#define BUFFER_SIZE_KEYBOARD 128
-#define BUFFER_SIZE_MOUSE 16
 }
 

--- a/Source/BansheeCore/Linux/BsLinuxKeyboard.cpp
+++ b/Source/BansheeCore/Linux/BsLinuxKeyboard.cpp
@@ -27,10 +27,10 @@ namespace bs
 
 	void Keyboard::capture()
 	{
+		Lock lock(LinuxPlatform::eventLock);
+
 		if(m->hasInputFocus)
 		{
-			Lock lock(LinuxPlatform::eventLock);
-
 			while (!LinuxPlatform::buttonEvents.empty())
 			{
 				LinuxButtonEvent& event = LinuxPlatform::buttonEvents.front();

--- a/Source/BansheeCore/Linux/BsLinuxKeyboard.cpp
+++ b/Source/BansheeCore/Linux/BsLinuxKeyboard.cpp
@@ -2,97 +2,50 @@
 //**************** Copyright (c) 2016 Marko Pintera (marko.pintera@gmail.com). All rights reserved. **********************//
 #include "Input/BsKeyboard.h"
 #include "Input/BsInput.h"
-#include "Linux/BsLinuxInput.h"
-#include <fcntl.h>
-#include <linux/input.h>
+#include "Linux/BsLinuxPlatform.h"
 
 namespace bs
 {
-	constexpr UINT32 MAX_DEVICES = 8;
 
 	/** Contains private data for the Linux Keyboard implementation. */
 	struct Keyboard::Pimpl
 	{
-		INT32 fileHandles[MAX_DEVICES];
 		bool hasInputFocus;
 	};
 
 	Keyboard::Keyboard(const String& name, Input* owner)
 		: mName(name), mOwner(owner)
 	{
-		InputPrivateData* pvtData = owner->_getPrivateData();
-
 		m = bs_new<Pimpl>();
 		m->hasInputFocus = true;
-
-		for(UINT32 i = 0; i < MAX_DEVICES; i++)
-			m->fileHandles[i] = -1;
-
-		UINT32 idx = 0;
-		for(auto& entry : pvtData->keyboards)
-		{
-			String eventPath = "/dev/input/event" + toString(entry);
-			m->fileHandles[idx] = open(eventPath.c_str(), O_RDWR | O_NONBLOCK);
-
-			if(m->fileHandles[idx] == -1)
-				LOGERR("Failed to open input event file handle for device: " + mName);
-
-			idx++;
-
-			if(idx >= MAX_DEVICES)
-				break;
-		}
 	}
 
 	Keyboard::~Keyboard()
 	{
-		for(UINT32 i = 0; i < MAX_DEVICES; i++)
-		{
-			if(m->fileHandles[i] != -1)
-				close(m->fileHandles[i]);
-		}
-
 		bs_delete(m);
 	}
 
 	void Keyboard::capture()
 	{
-		input_event events[BUFFER_SIZE_KEYBOARD];
-		for(UINT32 i = 0; i < MAX_DEVICES; i++)
+		if(m->hasInputFocus)
 		{
-			if(m->fileHandles[i] == -1)
-				continue;
+			Lock lock(LinuxPlatform::eventLock);
 
-			if(!m->hasInputFocus)
-				continue;
-
-			while(true)
+			while (!LinuxPlatform::buttonEvents.empty())
 			{
-				ssize_t numReadBytes = read(m->fileHandles[i], &events, sizeof(events));
-				if(numReadBytes < 0)
-					break;
-
-				UINT32 numEvents = numReadBytes / sizeof(input_event);
-				for(UINT32 j = 0; j < numEvents; ++j)
-				{
-					switch(events[j].type)
-					{
-					case EV_KEY:
-					{
-						ButtonCode bc = (ButtonCode)events[j].code;
-						if(bc < BC_MOUSE_LEFT)
-						{
-							if(events[j].value)
-								mOwner->_notifyButtonPressed(0, bc, (UINT64)events[j].time.tv_usec);
-							else
-								mOwner->_notifyButtonReleased(0, bc, (UINT64)events[j].time.tv_usec);
-						}
-					}
-						break;
-					default: break;
-					}
-				}
+				LinuxButtonEvent& event = LinuxPlatform::buttonEvents.front();
+				if(event.pressed)
+					mOwner->_notifyButtonPressed(0, event.button, event.timestamp);
+				else
+					mOwner->_notifyButtonReleased(0, event.button, event.timestamp);
+				LinuxPlatform::buttonEvents.pop();
 			}
+		}
+		else
+		{
+			// Discard queued data
+			while (!LinuxPlatform::buttonEvents.empty())
+				LinuxPlatform::buttonEvents.pop();
 		}
 	}
 

--- a/Source/BansheeCore/Linux/BsLinuxMouse.cpp
+++ b/Source/BansheeCore/Linux/BsLinuxMouse.cpp
@@ -2,161 +2,49 @@
 //**************** Copyright (c) 2016 Marko Pintera (marko.pintera@gmail.com). All rights reserved. **********************//
 #include "Input/BsMouse.h"
 #include "Input/BsInput.h"
-#include "Linux/BsLinuxInput.h"
-#include <fcntl.h>
-#include <linux/input.h>
+#include "Linux/BsLinuxPlatform.h"
 
 namespace bs
 {
-	constexpr UINT32 MAX_DEVICES = 8;
-
 	/** Contains private data for the Linux Mouse implementation. */
 	struct Mouse::Pimpl
 	{
-		INT32 fileHandles[MAX_DEVICES];
 		bool hasInputFocus;
 	};
 
 	Mouse::Mouse(const String& name, Input* owner)
 		: mName(name), mOwner(owner)
 	{
-		InputPrivateData* pvtData = owner->_getPrivateData();
-
 		m = bs_new<Pimpl>();
 		m->hasInputFocus = true;
-
-		for(UINT32 i = 0; i < MAX_DEVICES; i++)
-			m->fileHandles[i] = -1;
-
-		UINT32 idx = 0;
-		for(auto& entry : pvtData->mice)
-		{
-			String eventPath = "/dev/input/event" + toString(entry);
-			m->fileHandles[idx] = open(eventPath.c_str(), O_RDWR | O_NONBLOCK);
-
-			if(m->fileHandles[idx] == -1)
-				LOGERR("Failed to open input event file handle for device: " + mName);
-
-			idx++;
-
-			if(idx >= MAX_DEVICES)
-				break;
-		}
 	}
 
 	Mouse::~Mouse()
 	{
-		for(UINT32 i = 0; i < MAX_DEVICES; i++)
-		{
-			if(m->fileHandles[i] != -1)
-				close(m->fileHandles[i]);
-		}
-
 		bs_delete(m);
 	}
 
 	void Mouse::capture()
 	{
-		INT32 relX = 0;
-		INT32 relY = 0;
-		INT32 relZ = 0;
-
-		input_event events[BUFFER_SIZE_MOUSE];
-		for(UINT32 i = 0; i < MAX_DEVICES; i++)
+		if(m->hasInputFocus)
 		{
-			if(m->fileHandles[i] == -1)
-				continue;
-
-			while(true)
-			{
-				ssize_t numReadBytes = read(m->fileHandles[i], &events, sizeof(events));
-				if(numReadBytes < 0)
-					break;
-
-				if(!m->hasInputFocus)
-					continue;
-
-				UINT32 numEvents = numReadBytes / sizeof(input_event);
-				for(UINT32 j = 0; j < numEvents; ++j)
-				{
-					switch(events[j].type)
-					{
-					case EV_KEY:
-					{
-						ButtonCode bc = BC_UNASSIGNED;
-
-						// Unnamed mouse buttons
-						if(events[j].code >= BTN_MISC && events[j].code < BTN_MOUSE)
-							bc = (ButtonCode)((INT32)BC_MOUSE_BTN4 + (events[j].code - BTN_MISC));
-						// Named mouse buttons
-						else if(events[j].code >= BTN_MOUSE && events[j].code < BTN_JOYSTICK)
-						{
-							switch (events[j].code)
-							{
-							case BTN_LEFT:
-								bc = BC_MOUSE_LEFT;
-								break;
-							case BTN_MIDDLE:
-								bc = BC_MOUSE_MIDDLE;
-								break;
-							case BTN_RIGHT:
-								bc = BC_MOUSE_RIGHT;
-								break;
-							case BTN_SIDE:
-								bc = BC_MOUSE_BTN15;
-								break;
-							case BTN_EXTRA:
-								bc = BC_MOUSE_BTN16;
-								break;
-							case BTN_FORWARD:
-								bc = BC_MOUSE_BTN17;
-								break;
-							case BTN_BACK:
-								bc = BC_MOUSE_BTN18;
-								break;
-							case BTN_TASK:
-								bc = BC_MOUSE_BTN19;
-								break;
-							default:
-								break;
-							}
-						}
-
-						if(bc != BC_UNASSIGNED)
-						{
-							if (events[j].value)
-								mOwner->_notifyButtonPressed(0, bc, (UINT64) events[j].time.tv_usec);
-							else
-								mOwner->_notifyButtonReleased(0, bc, (UINT64) events[j].time.tv_usec);
-						}
-					}
-						break;
-					case EV_REL:
-					{
-						switch(events[j].code)
-						{
-						case REL_X:
-							relX += events[j].value;
-							break;
-						case REL_Y:
-							relY += events[j].value;
-							break;
-						case REL_WHEEL:
-							relZ += events[j].value;
-							break;
-						default:
-							break;
-						}
-						break;
-					}
-					default: break;
-					}
-				}
-			}
+			Lock lock(LinuxPlatform::eventLock);
+			double deltaX = round(LinuxPlatform::mouseMotionEvent.deltaX);
+			double deltaY = round(LinuxPlatform::mouseMotionEvent.deltaY);
+			double deltaZ = round(LinuxPlatform::mouseMotionEvent.deltaZ);
+			if (deltaX != 0 || deltaY != 0 || deltaZ != 0)
+				mOwner->_notifyMouseMoved(deltaX, deltaY, deltaZ);
+			LinuxPlatform::mouseMotionEvent.deltaX -= deltaX;
+			LinuxPlatform::mouseMotionEvent.deltaY -= deltaY;
+			LinuxPlatform::mouseMotionEvent.deltaZ -= deltaZ;
 		}
-
-		if(relX != 0 || relY != 0 || relZ != 0)
-			mOwner->_notifyMouseMoved(relX, relY, relZ);
+		else
+		{
+			// Discard accumulated data
+			LinuxPlatform::mouseMotionEvent.deltaX = 0;
+			LinuxPlatform::mouseMotionEvent.deltaY = 0;
+			LinuxPlatform::mouseMotionEvent.deltaZ = 0;
+		}
 	}
 
 	void Mouse::changeCaptureContext(UINT64 windowHandle)

--- a/Source/BansheeCore/Linux/BsLinuxMouse.cpp
+++ b/Source/BansheeCore/Linux/BsLinuxMouse.cpp
@@ -26,14 +26,17 @@ namespace bs
 
 	void Mouse::capture()
 	{
+		Lock lock(LinuxPlatform::eventLock);
+
 		if(m->hasInputFocus)
 		{
-			Lock lock(LinuxPlatform::eventLock);
 			double deltaX = round(LinuxPlatform::mouseMotionEvent.deltaX);
 			double deltaY = round(LinuxPlatform::mouseMotionEvent.deltaY);
 			double deltaZ = round(LinuxPlatform::mouseMotionEvent.deltaZ);
+
 			if (deltaX != 0 || deltaY != 0 || deltaZ != 0)
 				mOwner->_notifyMouseMoved(deltaX, deltaY, deltaZ);
+
 			LinuxPlatform::mouseMotionEvent.deltaX -= deltaX;
 			LinuxPlatform::mouseMotionEvent.deltaY -= deltaY;
 			LinuxPlatform::mouseMotionEvent.deltaZ -= deltaZ;

--- a/Source/BansheeCore/Linux/BsLinuxPlatform.cpp
+++ b/Source/BansheeCore/Linux/BsLinuxPlatform.cpp
@@ -764,8 +764,9 @@ namespace bs
 
 	/**
 	 * Enqueue a button press/release event to be handled by the main thread
-	 * @param bc ButtonCode for the button that was pressed or released
-	 * @param pressed true if the button was pressed, false if it was released
+	 *
+	 * @param bc        ButtonCode for the button that was pressed or released
+	 * @param pressed   true if the button was pressed, false if it was released
 	 * @param timestamp Time when the event happened
 	 */
 	void enqueueButtonEvent(ButtonCode bc, bool pressed, UINT64 timestamp)
@@ -807,9 +808,9 @@ namespace bs
 						// info is by axis name, so we can use the axis index directly just as well. GDK seems to assume
 						// 0 for x and 1 for y too, so that's hopefully safe, and 3 appears to be common for the scroll
 						// wheel.
-						Vector<double> deltas(4, 0);
+						float deltas[4] = {0};
 						int currentValuesIndex = 0;
-						for (unsigned int valuator = 0; valuator < deltas.size(); valuator++)
+						for (unsigned int valuator = 0; valuator < 4; valuator++)
 							if (XIMaskIsSet(xInput2Event->valuators.mask, valuator))
 								deltas[valuator] = xInput2Event->raw_values[currentValuesIndex++];
 
@@ -1228,6 +1229,7 @@ namespace bs
 		if (!XQueryExtension(mData->xDisplay, "XInputExtension", &mData->xInput2Opcode, &firstEvent, &firstError)) {
 			BS_EXCEPT(InternalErrorException, "X Server doesn't support the XInput extension");
 		}
+
 		int majorVersion = 2;
 		int minorVersion = 0;
 		if (XIQueryVersion(mData->xDisplay, &majorVersion, &minorVersion) != Success) {
@@ -1238,9 +1240,10 @@ namespace bs
 		XIEventMask mask;
 		mask.deviceid = XIAllDevices;
 		mask.mask_len = XIMaskLen(XI_LASTEVENT);
-		Vector<unsigned char> maskBuffer(mask.mask_len, 0);
-		mask.mask = maskBuffer.data();
+		unsigned char maskBuffer[mask.mask_len] = {0};
+		mask.mask = maskBuffer;
 		XISetMask(mask.mask, XI_RawMotion);
+
 		// "RawEvents are sent exclusively to all root windows", so this should receive all events, even though we only
 		// select on one display's root window (untested for lack of second screen).
 		XISelectEvents(mData->xDisplay, XRootWindow(mData->xDisplay, DefaultScreen(mData->xDisplay)), &mask, 1);

--- a/Source/BansheeCore/Linux/BsLinuxPlatform.h
+++ b/Source/BansheeCore/Linux/BsLinuxPlatform.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Platform/BsPlatform.h"
+#include "Linux/BsLinuxInput.h"
 #include <X11/X.h>
 #include <X11/Xlib.h>
 
@@ -43,6 +44,21 @@ namespace bs
 
 		/** Generates a X11 Pixmap from the provided pixel data. */
 		static Pixmap createPixmap(const PixelData& data, UINT32 depth);
+
+		/** Mutex for accessing buttonEvents / mouseEvent. */
+		static Mutex eventLock;
+
+		/**
+		 * Stores events captured on the core thread, waiting to be processed by the main thread.
+		 * Always lock on eventLock when accessing this.
+		 */
+		static Queue<LinuxButtonEvent> buttonEvents;
+
+		/**
+		 * Stores accumulated mouse motion events, waiting to be processed by the main thread.
+		 * Always lock on eventLock when accessing this.
+		 */
+		static LinuxMouseMotionEvent mouseMotionEvent;
 	};
 
 	/** @} */

--- a/Source/BansheeUtility/CMakeLists.txt
+++ b/Source/BansheeUtility/CMakeLists.txt
@@ -15,6 +15,10 @@ if(LINUX)
 	if(NOT X11_Xrandr_FOUND)
 		message(FATAL_ERROR "Could not find XRandR library.")
 	endif()
+
+	if(NOT X11_Xi_FOUND)
+		message(FATAL_ERROR "Could not find Xi (XInput) library.")
+	endif()
 endif()
 
 # Third party (non-package) libraries
@@ -52,7 +56,7 @@ else()
 	target_link_libraries(BansheeUtility PRIVATE dl pthread)
 
 	## External lib: X11, LibUUID
-	target_link_libraries(BansheeUtility PUBLIC ${X11_LIBRARIES} ${X11_Xcursor_LIB} ${X11_Xrandr_LIB})
+	target_link_libraries(BansheeUtility PUBLIC ${X11_LIBRARIES} ${X11_Xcursor_LIB} ${X11_Xrandr_LIB} ${X11_Xi_LIB})
 	target_link_libraries(BansheeUtility PRIVATE ${LibUUID_LIBRARIES})
 endif()
 


### PR DESCRIPTION
So there are now 3 commits: The first one you already reviewed, the second one removes now obsolete mouse/keyboard initialization code from BsLinuxInput, and the third one takes care of the changes you suggested for the first commit. I can squash them into 1 commit if you like, but it's probably easier for you this way to make sure the 2nd & 3rd are okay.