### PR TITLE
Use copy-and-remove on Unix/Linux when renaming a file fails

### DIFF
--- a/Source/BansheeUtility/Unix/BsUnixFileSystem.cpp
+++ b/Source/BansheeUtility/Unix/BsUnixFileSystem.cpp
@@ -111,8 +111,27 @@ namespace bs
 		String newPathStr = newPath.toString();
 		if (std::rename(oldPathStr.c_str(), newPathStr.c_str()) == -1)
 		{
-			LOGERR(String(__FUNCTION__) + ": renaming " + oldPathStr + " to " + newPathStr +
-			       ": " + strerror(errno));
+			// Cross-filesystem copy is likely needed (for example, /tmp to Banshee install dir while copying assets)
+		    std::ifstream src(oldPathStr.c_str(), std::ios::binary);
+			std::ofstream dst(newPathStr.c_str(), std::ios::binary);
+			dst << src.rdbuf(); // First, copy
+			
+			// Error handling
+			src.close();
+			if (!src)
+			
+			{
+				LOGERR(String(__FUNCTION__) + ": renaming " + oldPathStr + " to " + newPathStr +
+						": " + strerror(errno));
+				return; // Do not remove source if we failed!
+			}
+
+			// Then, remove source file (hopefully succeeds)
+			if (std::remove(oldPathStr.c_str()) == -1)
+			{
+				LOGERR(String(__FUNCTION__) + ": renaming " + oldPathStr + " to " + newPathStr +
+						": " + strerror(errno));
+			}
 		}
 	}
 

--- a/Source/BansheeUtility/Unix/BsUnixFileSystem.cpp
+++ b/Source/BansheeUtility/Unix/BsUnixFileSystem.cpp
@@ -119,7 +119,6 @@ namespace bs
 			// Error handling
 			src.close();
 			if (!src)
-			
 			{
 				LOGERR(String(__FUNCTION__) + ": renaming " + oldPathStr + " to " + newPathStr +
 						": " + strerror(errno));


### PR DESCRIPTION
This allows editor to properly launch when /tmp folder is in different partition than BansheeEngine data directory. For some weird reason, editor would previously _delete_ files instead of just failing to launch, but that doesn't happen either anymore.