### PR TITLE
Have git ignore the .vs folder that Visual Studio 2017 generates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ BsFrameworkConfig.h
 Source/Experimental
 Source/MBansheeEngine/Generated
 Source/MBansheeEditor/Generated
+.vs/*


### PR DESCRIPTION
It relies only on compile-time data, and so can be made into a static member function, and used in constexpr contexts.