### PR TITLE
Refactor: Revamp the about window

### DIFF
--- a/Source/EditorManaged/Windows/AboutBox.cs
+++ b/Source/EditorManaged/Windows/AboutBox.cs
@@ -9,7 +9,7 @@ namespace bs.Editor
      */
 
     /// <summary>
-    /// Displays information about the engine, its creator and licenses.
+    /// Displays information about the engine, its creators and licenses.
     /// </summary>
     public class AboutBox : ModalWindow
     {
@@ -30,45 +30,57 @@ namespace bs.Editor
         protected AboutBox()
             : base(true)
         {
-            Title = "About";
-            Width = 400;
+            Title = "About Banshee";
+            Width = 450;
             Height = 400;
         }
 
         private void OnInitialize()
         {
-            GUILabel title = new GUILabel(new LocEdString("Banshee Engine v0.4"), EditorStyles.TitleLabel);
-            GUILabel subTitle = new GUILabel(new LocEdString("A modern open-source game development toolkit"), 
+            GUILabel title = new GUILabel(new LocEdString("Banshee Editor " + EngineVersion.GetFullVersionString()), EditorStyles.TitleLabel);
+            GUILabel subTitle = new GUILabel(new LocEdString("A editor for modern open-source game development toolkit"), 
                 EditorStyles.LabelCentered);
+            GUILabel bsfVersion = new GUILabel(new LocEdString("Powered by bs::framework " + FrameworkVersion.GetFullVersionString()), EditorStyles.LabelCentered);
             GUILabel license = new GUILabel(new LocEdString(
-                "This program is licensed under the GNU Lesser General Public License V3"), EditorStyles.LabelCentered);
-            GUILabel copyright = new GUILabel(new LocEdString("Copyright (C) 2015 Marko Pintera. All rights reserved."), 
+                "This program is licensed under the GNU Lesser General Public License V3 or later"), EditorStyles.LabelCentered);
+            GUILabel copyright = new GUILabel(new LocEdString("Copyright (C) 2014 - " + EngineVersion.GetCurrentReleaseYearNumber() + " Marko Pintera and contributors. All rights reserved."), 
                 EditorStyles.LabelCentered);
+
+            GUILabel editorContributorsLabel = new GUILabel(new LocEdString("Editor contributors"), EditorStyles.TitleLabel);
+            GUILabel frameworkContributorsLabel = new GUILabel(new LocEdString("Framework contributors"), EditorStyles.TitleLabel);
+            GUILabel engineLabel = new GUILabel(new LocEdString("Editor and engine"), EditorStyles.TitleLabel);
+            GUILabel frameworkLabel = new GUILabel(new LocEdString("Framework"), EditorStyles.TitleLabel);
+
 
             GUILabel authorLabel = new GUILabel(new LocEdString("Banshee was created, and is being actively developed by Marko Pintera."));
             GUILabel emailTitle = new GUILabel(new LocEdString("E-mail"), GUIOption.FixedWidth(150));
             emailLabel = new GUITextBox();
             GUILabel linkedInTitle = new GUILabel(new LocEdString("LinkedIn"), GUIOption.FixedWidth(150));
             GUIButton linkedInBtn = new GUIButton(new LocEdString("Profile"));
-
+            GUIButton patreonBtn = new GUIButton(new LocEdString("Support us on Patreon!"), GUIOption.FixedWidth(210));
+            GUIButton paypalBtn = new GUIButton(new LocEdString("Donate via PayPal!"), GUIOption.FixedWidth(210));
+            
+            GUIScrollArea scrollArea = new GUIScrollArea();
             GUIToggleGroup foldoutGroup = new GUIToggleGroup(true);
-            GUIToggle contactFoldout = new GUIToggle(new LocEdString("Author"), foldoutGroup, EditorStyles.Foldout);
+            GUIToggle contactFoldout = new GUIToggle(new LocEdString("Main author"), foldoutGroup, EditorStyles.Foldout);
             GUIToggle thirdPartyFoldout = new GUIToggle(new LocEdString("Used third party libraries"), foldoutGroup, EditorStyles.Foldout);
             GUIToggle noticesFoldout = new GUIToggle(new LocEdString("Third party notices"), foldoutGroup, EditorStyles.Foldout);
-            GUIToggle collaboratorsFoldout = new GUIToggle(new LocEdString("Collaborators"), foldoutGroup, EditorStyles.Foldout);
+            GUIToggle contributorsFoldout = new GUIToggle(new LocEdString("Contributors"), foldoutGroup, EditorStyles.Foldout);
+            GUIToggle socialFoldout = new GUIToggle(new LocEdString("Social"), foldoutGroup, EditorStyles.Foldout);
 
             contactFoldout.AcceptsKeyFocus = false;
             thirdPartyFoldout.AcceptsKeyFocus = false;
             noticesFoldout.AcceptsKeyFocus = false;
-            collaboratorsFoldout.AcceptsKeyFocus = false;
+            contributorsFoldout.AcceptsKeyFocus = false;
+            socialFoldout.AcceptsKeyFocus = false;
 
             GUILabel freeTypeNotice = new GUILabel(new LocEdString(
-                        "Portions of this software are copyright (C) 2015 The FreeType Project (www.freetype.org). " +
+                        "Portions of this software are copyright (C) 2019 The FreeType Project (www.freetype.org). " +
                         "All rights reserved."), EditorStyles.MultiLineLabelCentered, 
                         GUIOption.FlexibleHeight(), GUIOption.FixedWidth(380));
 
             GUILabel fbxSdkNotice = new GUILabel(new LocEdString(
-                "This software contains Autodesk(R) FBX(R) code developed by Autodesk, Inc. Copyright 2013 Autodesk, Inc. " +
+                "This software contains Autodesk(R) FBX(R) code developed by Autodesk, Inc. Copyright 2019 Autodesk, Inc. " +
                 "All rights, reserved. Such code is provided \"as is\" and Autodesk, Inc. disclaims any and all warranties, " +
                 "whether express or implied, including without limitation the implied warranties of merchantability, " +
                 "fitness for a particular purpose or non-infringement of third party rights. In no event shall Autodesk, " +
@@ -77,18 +89,54 @@ namespace bs.Editor
                 "profits; or business interruption) however caused and on any theory of liability, whether in contract, " +
                 "strict liability, or tort (including negligence or otherwise) arising in any way out of such code."),
                 EditorStyles.MultiLineLabelCentered, GUIOption.FlexibleHeight(), GUIOption.FixedWidth(380));
+            
+            string[ , ] contributorListEditor = new string[ , ]
+            {
+                { "Danijel Ribic", "Logo, UI icons, 3D models & textures"},
+                { "Marco Bellan", "Bugfixes, editor enhancements" },
+                { "Robert Campbell", "Editor enhancements" },
+                { "James Mitchell", "Build enhancements"},
+                { "Patrick Recko", "Minor enhancements" }
+            };
+
+            string[] contributorListFramework = new string[]
+            {
+                "Marc Legendre",
+                "Florian Will",
+                "Marco Bellan",
+                "Artur K. (@nemerle)",
+                "Michael Jones",
+                "Connor Fitzgerald",
+                "Paolo Paoletto",
+                "Patrick Recko",
+                "Guillaume Meunier",
+                "Andre Taulien",
+                "James Mitchell",
+                "and others..."
+            };
 
             GUILayoutY mainLayout = GUI.AddLayoutY();
             mainLayout.AddSpace(10);
             mainLayout.AddElement(title);
             mainLayout.AddElement(subTitle);
             mainLayout.AddSpace(10);
+            mainLayout.AddElement(bsfVersion);
+            mainLayout.AddSpace(10);
             mainLayout.AddElement(license);
+            mainLayout.AddSpace(5);
             mainLayout.AddElement(copyright);
             mainLayout.AddSpace(10);
-            mainLayout.AddElement(contactFoldout);
+            GUILayoutX donateButtonLayoutX = mainLayout.AddLayoutX();
+            donateButtonLayoutX.AddSpace(10);
+            donateButtonLayoutX.AddElement(patreonBtn);
+            donateButtonLayoutX.AddSpace(10);
+            donateButtonLayoutX.AddElement(paypalBtn);
+            donateButtonLayoutX.AddSpace(10);
+            mainLayout.AddSpace(10);
 
-            GUILayoutY contactLayout = mainLayout.AddLayoutY();
+            mainLayout.AddElement(scrollArea);
+            scrollArea.Layout.AddElement(contactFoldout);
+            GUILayoutY contactLayout = scrollArea.Layout.AddLayoutY();
             contactLayout.AddSpace(15);
             GUILayout authorLayout = contactLayout.AddLayoutX();
             authorLayout.AddFlexibleSpace();
@@ -106,42 +154,76 @@ namespace bs.Editor
             linkedInLayout.AddElement(linkedInBtn);
             linkedInLayout.AddSpace(10);
 
-            mainLayout.AddSpace(5);
-            mainLayout.AddElement(thirdPartyFoldout);
-            GUILayoutY thirdPartyLayout = mainLayout.AddLayoutY();
+            scrollArea.Layout.AddSpace(5);
+            scrollArea.Layout.AddElement(thirdPartyFoldout);
+            GUILayoutY thirdPartyLayout = scrollArea.Layout.AddLayoutY();
+            thirdPartyLayout.AddSpace(5);
+            CreateNameURLBtnPair(thirdPartyLayout, "Autodesk FBX SDK",
+                "https://www.autodesk.com/products/fbx/overview", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "FreeImage", "http://freeimage.sourceforge.net/", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "FreeType", "http://www.freetype.org/", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "Mono", "http://www.mono-project.com/", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "NVIDIA Texture Tools",
+                "https://github.com/castano/nvidia-texture-tools", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "libFLAC", "https://xiph.org/flac/", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "libOgg", "https://www.xiph.org/ogg/", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "libVorbis", "http://www.vorbis.com/", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "OpenAL Soft", "http://kcat.strangesoft.net/openal.html", "Website");
+            CreateNameURLBtnPair(thirdPartyLayout, "NVIDIA PhysX", "https://developer.nvidia.com/physx-sdk", "Website");
 
-            CreateThirdPartyGUI(thirdPartyLayout, "Autodesk FBX SDK",
-                "http://usa.autodesk.com/adsk/servlet/pc/item?siteID=123112&id=10775847");
-            CreateThirdPartyGUI(thirdPartyLayout, "FreeImage", "http://freeimage.sourceforge.net/");
-            CreateThirdPartyGUI(thirdPartyLayout, "FreeType", "http://www.freetype.org/");
-            CreateThirdPartyGUI(thirdPartyLayout, "Mono", "http://www.mono-project.com/");
-            CreateThirdPartyGUI(thirdPartyLayout, "NVIDIA Texture Tools",
-                "https://github.com/castano/nvidia-texture-tools");
-            CreateThirdPartyGUI(thirdPartyLayout, "libFLAC", "https://xiph.org/flac/");
-            CreateThirdPartyGUI(thirdPartyLayout, "libOgg", "https://www.xiph.org/ogg/");
-            CreateThirdPartyGUI(thirdPartyLayout, "libVorbis", "http://www.vorbis.com/");
-            CreateThirdPartyGUI(thirdPartyLayout, "OpenAL Soft", "http://kcat.strangesoft.net/openal.html");
-
-            mainLayout.AddSpace(5);
-            mainLayout.AddElement(noticesFoldout);
-            GUILayout noticesLayout = mainLayout.AddLayoutY();
+            scrollArea.Layout.AddSpace(5);
+            scrollArea.Layout.AddElement(noticesFoldout);
+            GUILayout noticesLayout = scrollArea.Layout.AddLayoutY();
+            noticesLayout.AddSpace(5);
             noticesLayout.AddElement(freeTypeNotice);
             noticesLayout.AddSpace(10);
             noticesLayout.AddElement(fbxSdkNotice);
 
-            mainLayout.AddSpace(5);
-            mainLayout.AddElement(collaboratorsFoldout);
-            GUILayoutY collaboratorsLayout = mainLayout.AddLayoutY();
-            CreateCollaboratorGUI(collaboratorsLayout, "Danijel Ribic", "Logo, UI icons, 3D models & textures");
-            CreateCollaboratorGUI(collaboratorsLayout, "Marco Bellan", "Bugfixes, editor enhancements");
+            scrollArea.Layout.AddSpace(5);
+            scrollArea.Layout.AddElement(contributorsFoldout);
+            GUILayoutY contributorsLayout = scrollArea.Layout.AddLayoutY();
+            contributorsLayout.AddSpace(5);
+            contributorsLayout.AddElement(editorContributorsLabel);
+            contributorsLayout.AddSpace(5);
+            for (int i = 0; i < contributorListEditor.Length / 2; i++)
+            {
+                CreateEditorContributorGUI(contributorsLayout, contributorListEditor[i, 0], contributorListEditor[i, 1]);
+                contributorsLayout.AddSpace(5);
+            }
+            contributorsLayout.AddSpace(10);
+            contributorsLayout.AddElement(frameworkContributorsLabel);
+            contributorsLayout.AddSpace(5);
+            for (int i = 0; i < contributorListFramework.Length; i++)
+            {
+                CreateFrameworkContributorGUI(contributorsLayout, contributorListFramework[i]);
+                contributorsLayout.AddSpace(5);
+            }
 
+            scrollArea.Layout.AddSpace(5);
+            scrollArea.Layout.AddElement(socialFoldout);
+            GUILayoutY socialLayout = scrollArea.Layout.AddLayoutY();
+            socialLayout.AddSpace(10);
+            CreateNameURLBtnPair(socialLayout, "Discord", "https://discord.gg/8Xyf5gF", "Enter");
+            socialLayout.AddSpace(10);
+            socialLayout.AddElement(engineLabel);
+            socialLayout.AddSpace(5);
+            CreateNameURLBtnPair(socialLayout, "Website", "http://www.banshee3d.com", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Repository", "https://github.com/BearishSun/BansheeEngine", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Forums", "https://forum.banshee3d.com", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Twitter", "https://twitter.com/Banshee3D", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Facebook", "https://www.facebook.com/Banshee3D", "Enter");
+            socialLayout.AddSpace(10);
+            socialLayout.AddElement(frameworkLabel);
+            socialLayout.AddSpace(5);
+            CreateNameURLBtnPair(socialLayout, "Website", "http://www.bsframework.io", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Repository", "https://github.com/GameFoundry/bsf", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Forums", "https://discourse.bsframework.io/", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Twitter", "https://twitter.com/thebsframework", "Enter");
+            CreateNameURLBtnPair(socialLayout, "Facebook", "https://www.facebook.com/bsframework", "Enter");
             mainLayout.AddFlexibleSpace();
 
             contactLayout.Active = false;
-            contactFoldout.OnToggled += x =>
-            {
-                contactLayout.Active = x;
-            };
+            contactFoldout.OnToggled += x => contactLayout.Active = x;
 
             thirdPartyLayout.Active = false;
             thirdPartyFoldout.OnToggled += x => thirdPartyLayout.Active = x;
@@ -149,17 +231,22 @@ namespace bs.Editor
             noticesLayout.Active = false;
             noticesFoldout.OnToggled += x => noticesLayout.Active = x;
 
-            collaboratorsLayout.Active = false;
-            collaboratorsFoldout.OnToggled += x => collaboratorsLayout.Active = x;
+            contributorsLayout.Active = false;
+            contributorsFoldout.OnToggled += x => contributorsLayout.Active = x;
+
+            socialLayout.Active = false;
+            socialFoldout.OnToggled += x => socialLayout.Active = x;
 
             emailLabel.Text = "marko.pintera@gmail.com";
-            linkedInBtn.OnClick += () => { System.Diagnostics.Process.Start("http://hr.linkedin.com/in/markopintera"); };
+            linkedInBtn.OnClick += () => { System.Diagnostics.Process.Start("https://www.linkedin.com/in/markopintera"); };
+            patreonBtn.OnClick += () => { System.Diagnostics.Process.Start("https://www.patreon.com/bsf"); };
+            paypalBtn.OnClick += () => { System.Diagnostics.Process.Start("https://www.paypal.me/MarkoPintera/10"); };
         }
 
-        private void CreateThirdPartyGUI(GUILayoutY layout, string name, string webURL)
+        private void CreateNameURLBtnPair(GUILayoutY layout, string name, string webURL, string btnText)
         {
-            GUILabel label = new GUILabel(new LocEdString(name), GUIOption.FixedWidth(150));
-            GUIButton linkBtn = new GUIButton(new LocEdString("Website"), GUIOption.FixedWidth(50));
+            GUILabel label = new GUILabel(new LocEdString(name), GUIOption.FixedWidth(300));
+            GUIButton linkBtn = new GUIButton(new LocEdString(btnText), GUIOption.FixedWidth(100));
 
             GUILayoutX horzLayout = layout.AddLayoutX();
             horzLayout.AddSpace(10);
@@ -171,7 +258,7 @@ namespace bs.Editor
             linkBtn.OnClick += () => { System.Diagnostics.Process.Start(webURL); };
         }
 
-        private void CreateCollaboratorGUI(GUILayoutY layout, string name, string area)
+        private void CreateEditorContributorGUI(GUILayoutY layout, string name, string area)
         {
             GUILabel nameLabel = new GUILabel(new LocEdString(name), GUIOption.FixedWidth(150));
             GUILabel areaLabel = new GUILabel(new LocEdString(area), GUIOption.FixedWidth(220));
@@ -182,6 +269,14 @@ namespace bs.Editor
             horzLayout.AddSpace(10);
             horzLayout.AddElement(areaLabel);
             horzLayout.AddSpace(10);
+        }
+
+        private void CreateFrameworkContributorGUI(GUILayoutY layout, string name)
+        {
+            GUILabel nameLabel = new GUILabel(new LocEdString(name), EditorStyles.LabelCentered);
+
+            GUILayoutX horzLayout = layout.AddLayoutX();
+            horzLayout.AddElement(nameLabel);
         }
 
         private void OnEditorUpdate()


### PR DESCRIPTION
This PR revamps the entire about window, adding framework information, donation buttons, social networking links and extends the list of contributors.
It also takes the engine and framework versions for about titles from the appropriate version classes.

![pUoVAgPgQ6](https://user-images.githubusercontent.com/1986280/57018396-a9cdc200-6c23-11e9-82d7-241e5a9186fd.gif)

